### PR TITLE
Add RUNTIME DESTINATION to install target

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -97,4 +97,5 @@ endif()
 list(APPEND llvm_deps "${LLVM_PTHREAD_LIB}")
 
 target_link_libraries(lldb-mi ${lib_lldb} ${lib_llvm} ${llvm_deps})
-install( TARGETS lldb-mi)
+install(TARGETS lldb-mi
+  RUNTIME DESTINATION bin)


### PR DESCRIPTION
Fix for folowing build error:
CMake Error at src/CMakeLists.txt:100 (install):
  install TARGETS given no RUNTIME DESTINATION for executable target
  "lldb-mi".